### PR TITLE
hideCloseButton, modal options and button event guard code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Key Differences
  * Fixed closure on button reactivity
  * More reactive parts
  * hideCloseButton option
+ * Pass-though of options object on modal initialisation
 
 How to Use
 =========
@@ -37,7 +38,7 @@ Meteor.startup(function(){
     modalFooterClass: "share-modal-footer", // optional
     removeOnHide: true, // optional. If this is true, modal will be removed from DOM upon hiding
     hideCloseButton=true, // optional. If this true, the modal header will not show the &times; close button
-    modalOptions: { // optional. Pass - through of the Boostrap Modal options object on initialisation
+    modalOptions: { // optional. Pass - through of the Boostrap Modal options object, applied on initialisation
       keyboard: false,
       backdrop: 'static',
       show: false

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Meteor.startup(function(){
     modalFooterClass: "share-modal-footer", // optional
     removeOnHide: true, // optional. If this is true, modal will be removed from DOM upon hiding
     hideCloseButton=true, // optional. If this true, the modal header will not show the &times; close button
+    modalOptions: { // optional. Pass - through of the Boostrap Modal options object on initialisation
+      keyboard: false,
+      backdrop: 'static',
+      show: false
+      }, 
     buttons: {
       "cancel": {
         class: 'btn-danger',

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Key Differences
  * Ability to reuse shareDialogInfo objects
  * Fixed closure on button reactivity
  * More reactive parts
+ * hideCloseButton option
 
 How to Use
 =========
@@ -35,6 +36,7 @@ Meteor.startup(function(){
     modalBodyClass: "share-modal-body", // optional
     modalFooterClass: "share-modal-footer", // optional
     removeOnHide: true, // optional. If this is true, modal will be removed from DOM upon hiding
+    hideCloseButton=true, // optional. If this true, the modal header will not show the &times; close button
     buttons: {
       "cancel": {
         class: 'btn-danger',

--- a/lib/reactive-modal.html
+++ b/lib/reactive-modal.html
@@ -3,7 +3,9 @@
     <div class="modal-dialog {{modalDialogClass}}">
       <div class="modal-content">
         <div class="modal-header">
+          {{#unless hideCloseButton}}
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+          {{/unless}}
           <h4 class="modal-title" id="{{key}}Label">{{title}}</h4>
         </div>
         <div class="modal-body {{modalBodyClass}}">

--- a/lib/reactive-modal.js
+++ b/lib/reactive-modal.js
@@ -76,6 +76,11 @@ ReactiveModal.initDialog = function (info){
   }
 
   var modalTarget = $('#' + key);
+  if (info.modalOptions) {
+    // Initialise modal with options object
+    modalTarget.modal(info.modalOptions);
+  }
+  
   info.show = function(){
     modalTarget.modal('show');
   }

--- a/lib/reactive-modal.js
+++ b/lib/reactive-modal.js
@@ -36,7 +36,9 @@ Template._reactiveModal.helpers({
 
 Template._reactiveModal.events({
   'click .modal-footer .reactive-modal-btn.btn': function(e){
-    this.button.emit('click', this.button);
+    if (this.button && _.isFunction(this.button.emit)) {
+      this.button.emit('click', this.button);
+    }
   }
 });
 
@@ -80,7 +82,7 @@ ReactiveModal.initDialog = function (info){
     // Initialise modal with options object
     modalTarget.modal(info.modalOptions);
   }
-  
+
   info.show = function(){
     modalTarget.modal('show');
   }


### PR DESCRIPTION
Optionally remove the &times; close button from the modal header

fyi - I have a couple more enhancements to come, but I wanted to split them into separate PRs...I'll comment in the PRs on the last one. 
Basically, I need to (optionally) remove all of the alternative ways of closing a bootstrap modal other than a 'Cancel' button I define in the modal footer (the &times; button, pressing Escape key, and clicking on modal background), because it is really confusing the users of my application. 
